### PR TITLE
Move asset hub fee config to xcm config

### DIFF
--- a/cumulus/parachains/common/src/snowbridge_config.rs
+++ b/cumulus/parachains/common/src/snowbridge_config.rs
@@ -1,9 +1,0 @@
-frame_support::parameter_types! {
-	/// User fee for ERC20 token transfer back to Ethereum.
-	/// (initially was calculated by test `OutboundQueue::calculate_fees` - ETH/ROC 1/400 and fee_per_gas 20 GWEI = 2200698000000 + *25%)
-	/// Needs to be more than fee calculated from DefaultFeeConfig FeeConfigRecord in snowbridge:parachain/pallets/outbound-queue/src/lib.rs
-	/// Polkadot uses 12 decimals, Kusama and Rococo 10 decimals.
-	pub const BridgeHubEthereumBaseFeeInDOT: u128 = 27_508_725_000;
-	pub const BridgeHubEthereumBaseFeeInKSM: u128 = 2_750_872_500_000;
-	pub const BridgeHubEthereumBaseFeeInRocs: u128 = 2_750_872_500_000;
-}

--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/xcm_config.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/xcm_config.rs
@@ -851,6 +851,11 @@ pub mod bridging {
 		parameter_types! {
 			pub EthereumNetwork: NetworkId = NetworkId::Ethereum { chain_id: 15 };
 			pub EthereumLocation: MultiLocation = MultiLocation::new(2, X1(GlobalConsensus(EthereumNetwork::get())));
+			/// User fee for ERC20 token transfer back to Ethereum.
+			/// (initially was calculated by test `OutboundQueue::calculate_fees` - ETH/ROC 1/400 and fee_per_gas 20 GWEI = 2200698000000 + *25%)
+			/// Needs to be more than fee calculated from DefaultFeeConfig FeeConfigRecord in snowbridge:parachain/pallets/outbound-queue/src/lib.rs
+			/// Polkadot uses 12 decimals, Kusama and Rococo 10 decimals.
+			pub const BridgeHubEthereumBaseFeeInROC: u128 = 2_750_872_500_000;
 
 			/// Set up exporters configuration.
 			/// `Option<MultiAsset>` represents static "base fee" which is used for total delivery fee calculation.
@@ -863,7 +868,7 @@ pub mod bridging {
 					SiblingBridgeHub::get(),
 					Some((
 						XcmBridgeHubRouterFeeAssetId::get(),
-						BridgeHubEthereumBaseFeeInRocs::get(),
+						BridgeHubEthereumBaseFeeInROC::get(),
 					).into())
 				),
 			];


### PR DESCRIPTION
I moved it to the xcm_config instead of the runtime lib, since it is related to xcm config. I also left out the KSM and DOT config, since we can add the fee config when we submit the xcm config changes to the Kusama and Polkadot runtimes.