### PR TITLE
Remove old mod

### DIFF
--- a/cumulus/parachains/common/src/lib.rs
+++ b/cumulus/parachains/common/src/lib.rs
@@ -20,7 +20,6 @@ pub mod kusama;
 pub mod message_queue;
 pub mod polkadot;
 pub mod rococo;
-pub mod snowbridge_config;
 pub mod westend;
 pub mod wococo;
 pub mod xcm_config;


### PR DESCRIPTION
Should have been part of https://github.com/Snowfork/polkadot-sdk/pull/41.