### PR TITLE
Set beacon mainnet spec as default

### DIFF
--- a/cumulus/polkadot-parachain/Cargo.toml
+++ b/cumulus/polkadot-parachain/Cargo.toml
@@ -159,4 +159,6 @@ try-runtime = [
 	"shell-runtime/try-runtime",
 	"sp-runtime/try-runtime",
 ]
-beacon-spec-mainnet = []
+beacon-spec-mainnet = [
+	"bridge-hub-rococo-runtime/beacon-spec-mainnet"
+]

--- a/cumulus/polkadot-parachain/Cargo.toml
+++ b/cumulus/polkadot-parachain/Cargo.toml
@@ -110,7 +110,9 @@ tokio = { version = "1.32.0", features = ["macros", "time", "parking_lot"] }
 wait-timeout = "0.2"
 
 [features]
-default = []
+default = [
+	"beacon-spec-mainnet"
+]
 runtime-benchmarks = [
 	"asset-hub-kusama-runtime/runtime-benchmarks",
 	"asset-hub-polkadot-runtime/runtime-benchmarks",


### PR DESCRIPTION
The beacon mainnet spec should be the default spec, and then we'll specify `--no-default-features` when building the bridge for testnet cases.
Snowbridge companion: https://github.com/Snowfork/snowbridge/pull/1045