### PR TITLE
Reset Nonces in Rococo

### DIFF
--- a/cumulus/parachains/runtimes/bridge-hubs/test-utils/src/test_cases/mod.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/test-utils/src/test_cases/mod.rs
@@ -72,7 +72,9 @@ pub type RuntimeHelper<Runtime, AllPalletsWithoutSystem = ()> =
 	parachains_runtimes_test_utils::RuntimeHelper<Runtime, AllPalletsWithoutSystem>;
 
 // Re-export test_case from `parachains-runtimes-test-utils`
-pub use parachains_runtimes_test_utils::test_cases::change_storage_constant_by_governance_works;
+pub use parachains_runtimes_test_utils::test_cases::{
+	change_storage_constant_by_governance_works, kill_storage_keys_by_governance_works,
+};
 
 /// Prepare default runtime storage and run test within this context.
 pub fn run_test<Runtime, T>(

--- a/cumulus/parachains/runtimes/bridge-hubs/test-utils/src/test_cases/mod.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/test-utils/src/test_cases/mod.rs
@@ -73,7 +73,7 @@ pub type RuntimeHelper<Runtime, AllPalletsWithoutSystem = ()> =
 
 // Re-export test_case from `parachains-runtimes-test-utils`
 pub use parachains_runtimes_test_utils::test_cases::{
-	change_storage_constant_by_governance_works, kill_storage_keys_by_governance_works,
+	change_storage_constant_by_governance_works, set_storage_keys_by_governance_works,
 };
 
 /// Prepare default runtime storage and run test within this context.

--- a/cumulus/parachains/runtimes/test-utils/src/test_cases.rs
+++ b/cumulus/parachains/runtimes/test-utils/src/test_cases.rs
@@ -91,3 +91,53 @@ pub fn change_storage_constant_by_governance_works<Runtime, StorageConstant, Sto
 			);
 		})
 }
+
+/// Test-case makes sure that `Runtime` can kill storage constant via governance-like call
+pub fn kill_storage_keys_by_governance_works<Runtime>(
+	collator_session_key: CollatorSessionKeys<Runtime>,
+	runtime_para_id: u32,
+	runtime_call_encode: Box<dyn Fn(frame_system::Call<Runtime>) -> Vec<u8>>,
+	storage_constant_key: Vec<u8>,
+	initialize_storage: impl FnOnce() -> (),
+	assert_storage: impl FnOnce() -> (),
+) where
+	Runtime: frame_system::Config
+		+ pallet_balances::Config
+		+ pallet_session::Config
+		+ pallet_xcm::Config
+		+ parachain_info::Config
+		+ pallet_collator_selection::Config
+		+ cumulus_pallet_parachain_system::Config,
+	ValidatorIdOf<Runtime>: From<AccountIdOf<Runtime>>,
+{
+	let mut runtime = ExtBuilder::<Runtime>::default()
+		.with_collators(collator_session_key.collators())
+		.with_session_keys(collator_session_key.session_keys())
+		.with_para_id(runtime_para_id.into())
+		.with_tracing()
+		.build();
+	runtime.execute_with(|| {
+		initialize_storage();
+	});
+	runtime.execute_with(|| {
+		// encode `kill_storage` call
+		let kill_storage_call = runtime_call_encode(frame_system::Call::<Runtime>::kill_storage {
+			keys: vec![storage_constant_key.clone()],
+		});
+
+		// estimate - storing just 1 value
+		use frame_system::WeightInfo;
+		let require_weight_at_most =
+			<Runtime as frame_system::Config>::SystemWeightInfo::kill_storage(1);
+
+		// execute XCM with Transact to `set_storage` as governance does
+		assert_ok!(RuntimeHelper::<Runtime>::execute_as_governance(
+			kill_storage_call,
+			require_weight_at_most
+		)
+		.ensure_complete());
+	});
+	runtime.execute_with(|| {
+		assert_storage();
+	});
+}


### PR DESCRIPTION
In the event we need to re-initialize our test, we will need to reset our nonces to zero. This will allow this to happen in Rococo.

Snowbridge Companion: https://github.com/Snowfork/snowbridge/pull/1128
Resolves: [SNO-836](https://linear.app/snowfork/issue/SNO-836)