### PR TITLE
Reject finalized updates without a sync committee in next store period

### DIFF
--- a/bridges/snowbridge/pallets/ethereum-client/src/lib.rs
+++ b/bridges/snowbridge/pallets/ethereum-client/src/lib.rs
@@ -432,9 +432,9 @@ pub mod pallet {
 			let latest_finalized_state =
 				FinalizedBeaconState::<T>::get(LatestFinalizedBlockRoot::<T>::get())
 					.ok_or(Error::<T>::NotBootstrapped)?;
+			let store_period = compute_period(latest_finalized_state.slot);
+			let update_finalized_period = compute_period(update.finalized_header.slot);
 			if let Some(next_sync_committee_update) = &update.next_sync_committee_update {
-				let store_period = compute_period(latest_finalized_state.slot);
-				let update_finalized_period = compute_period(update.finalized_header.slot);
 				let sync_committee_prepared: SyncCommitteePrepared = (&next_sync_committee_update
 					.next_sync_committee)
 					.try_into()
@@ -458,7 +458,15 @@ pub mod pallet {
 				Self::deposit_event(Event::SyncCommitteeUpdated {
 					period: update_finalized_period,
 				});
-			};
+			} else {
+				// If there was no sync committee in the update, but the finalized header provided
+				// is in the new period, we need to move the sync committee period forward.
+				if update_finalized_period == store_period + 1 {
+					log::info!(target: LOG_TARGET, "💫 Rolling over next sync committee to current sync committee. Next sync committee empty. store_period = {}", store_period);
+					<CurrentSyncCommittee<T>>::set(<NextSyncCommittee<T>>::get());
+					<NextSyncCommittee<T>>::kill();
+				}
+			}
 
 			if update.finalized_header.slot > latest_finalized_state.slot {
 				Self::store_finalized_header(update.finalized_header, update.block_roots_root)?;

--- a/bridges/snowbridge/pallets/ethereum-client/src/lib.rs
+++ b/bridges/snowbridge/pallets/ethereum-client/src/lib.rs
@@ -398,7 +398,10 @@ pub mod pallet {
 					Error::<T>::InvalidSyncCommitteeMerkleProof
 				);
 			} else {
-				ensure!(update_finalized_period == store_period, <Error<T>>::SyncCommitteeUpdateRequired);
+				ensure!(
+					update_finalized_period == store_period,
+					<Error<T>>::SyncCommitteeUpdateRequired
+				);
 			}
 
 			// Verify sync committee aggregate signature.

--- a/bridges/snowbridge/pallets/ethereum-client/src/lib.rs
+++ b/bridges/snowbridge/pallets/ethereum-client/src/lib.rs
@@ -465,7 +465,6 @@ pub mod pallet {
 				// If there was no sync committee in the update, but the finalized header provided
 				// is in the new period, we need to move the sync committee period forward.
 				if update_finalized_period == store_period + 1 {
-					ensure!(<NextSyncCommittee<T>>::exists(), <Error<T>>::NextSyncCommitteeUnknown);
 					CurrentSyncCommittee::<T>::set(NextSyncCommittee::<T>::take());
 				}
 			}

--- a/bridges/snowbridge/pallets/ethereum-client/src/lib.rs
+++ b/bridges/snowbridge/pallets/ethereum-client/src/lib.rs
@@ -321,6 +321,7 @@ pub mod pallet {
 
 			// Verify update is relevant.
 			let update_attested_period = compute_period(update.attested_header.slot);
+			let update_finalized_period = compute_period(update.finalized_header.slot);
 			let update_has_next_sync_committee = !<NextSyncCommittee<T>>::exists() &&
 				(update.next_sync_committee_update.is_some() &&
 					update_attested_period == store_period);

--- a/bridges/snowbridge/pallets/ethereum-client/src/lib.rs
+++ b/bridges/snowbridge/pallets/ethereum-client/src/lib.rs
@@ -104,6 +104,7 @@ pub mod pallet {
 	#[pallet::error]
 	pub enum Error<T> {
 		SkippedSyncCommitteePeriod,
+		NextSyncCommitteeUnknown,
 		/// Attested header is older than latest finalized header.
 		IrrelevantUpdate,
 		NotBootstrapped,
@@ -462,7 +463,8 @@ pub mod pallet {
 				// If there was no sync committee in the update, but the finalized header provided
 				// is in the new period, we need to move the sync committee period forward.
 				if update_finalized_period == store_period + 1 {
-CurrentSyncCommittee::<T>::set(NextSyncCommittee::<T>::take());
+					ensure!(<NextSyncCommittee<T>>::exists(), <Error<T>>::NextSyncCommitteeUnknown);
+					CurrentSyncCommittee::<T>::set(NextSyncCommittee::<T>::take());
 				}
 			}
 

--- a/bridges/snowbridge/pallets/ethereum-client/src/lib.rs
+++ b/bridges/snowbridge/pallets/ethereum-client/src/lib.rs
@@ -462,7 +462,6 @@ pub mod pallet {
 				// If there was no sync committee in the update, but the finalized header provided
 				// is in the new period, we need to move the sync committee period forward.
 				if update_finalized_period == store_period + 1 {
-					log::info!(target: LOG_TARGET, "💫 Rolling over next sync committee to current sync committee. Next sync committee empty. store_period = {}", store_period);
 					<CurrentSyncCommittee<T>>::set(<NextSyncCommittee<T>>::get());
 					<NextSyncCommittee<T>>::kill();
 				}

--- a/bridges/snowbridge/pallets/ethereum-client/src/lib.rs
+++ b/bridges/snowbridge/pallets/ethereum-client/src/lib.rs
@@ -462,8 +462,7 @@ pub mod pallet {
 				// If there was no sync committee in the update, but the finalized header provided
 				// is in the new period, we need to move the sync committee period forward.
 				if update_finalized_period == store_period + 1 {
-					<CurrentSyncCommittee<T>>::set(<NextSyncCommittee<T>>::get());
-					<NextSyncCommittee<T>>::kill();
+CurrentSyncCommittee::<T>::set(NextSyncCommittee::<T>::take());
 				}
 			}
 

--- a/bridges/snowbridge/pallets/ethereum-client/src/lib.rs
+++ b/bridges/snowbridge/pallets/ethereum-client/src/lib.rs
@@ -396,6 +396,8 @@ pub mod pallet {
 					),
 					Error::<T>::InvalidSyncCommitteeMerkleProof
 				);
+			} else if update_finalized_period == store_period + 1 {
+				ensure!(<NextSyncCommittee<T>>::exists(), <Error<T>>::NextSyncCommitteeUnknown);
 			}
 
 			// Verify sync committee aggregate signature.

--- a/bridges/snowbridge/pallets/ethereum-client/src/lib.rs
+++ b/bridges/snowbridge/pallets/ethereum-client/src/lib.rs
@@ -400,7 +400,7 @@ pub mod pallet {
 			} else {
 				ensure!(
 					update_finalized_period == store_period,
-					<Error<T>>::SyncCommitteeUpdateRequired
+					Error::<T>::SyncCommitteeUpdateRequired
 				);
 			}
 

--- a/bridges/snowbridge/pallets/ethereum-client/src/tests.rs
+++ b/bridges/snowbridge/pallets/ethereum-client/src/tests.rs
@@ -475,11 +475,15 @@ fn submit_update_in_next_period_without_sync_committee_update() {
 			RuntimeOrigin::signed(1),
 			sync_committee_update.clone()
 		));
-		assert_ok!(EthereumBeaconClient::submit(RuntimeOrigin::signed(1), update));
+		assert_err!(
+			EthereumBeaconClient::submit(RuntimeOrigin::signed(1), update.clone()), 
+			SyncCommitteeUpdateRequired
+		);
 		assert_ok!(EthereumBeaconClient::submit(
 			RuntimeOrigin::signed(1),
 			next_sync_committee_update
-		),);
+		));
+		assert_ok!(EthereumBeaconClient::submit(RuntimeOrigin::signed(1), update));
 	});
 }
 

--- a/bridges/snowbridge/pallets/ethereum-client/src/tests.rs
+++ b/bridges/snowbridge/pallets/ethereum-client/src/tests.rs
@@ -362,13 +362,14 @@ fn submit_update_with_sync_committee_in_current_period() {
 }
 
 #[test]
-fn submit_update_in_next_period() {
+fn reject_submit_update_in_next_period() {
 	let checkpoint = Box::new(load_checkpoint_update_fixture());
 	let sync_committee_update = Box::new(load_sync_committee_update_fixture());
 	let update = Box::new(load_next_finalized_header_update_fixture());
 	let sync_committee_period = compute_period(sync_committee_update.finalized_header.slot);
 	let next_sync_committee_period = compute_period(update.finalized_header.slot);
 	assert_eq!(sync_committee_period + 1, next_sync_committee_period);
+	let next_sync_committee_update = Box::new(load_next_sync_committee_update_fixture());
 
 	new_tester().execute_with(|| {
 		assert_ok!(EthereumBeaconClient::process_checkpoint_update(&checkpoint));
@@ -376,9 +377,18 @@ fn submit_update_in_next_period() {
 			RuntimeOrigin::signed(1),
 			sync_committee_update.clone()
 		));
+		// check an update in the next period is rejected
+		assert_err!(
+			EthereumBeaconClient::submit(RuntimeOrigin::signed(1), update.clone()),
+			Error::<Test>::SyncCommitteeUpdateRequired
+		);
+		// submit update with next sync committee
+		assert_ok!(EthereumBeaconClient::submit(
+			RuntimeOrigin::signed(1),
+			next_sync_committee_update
+		));
+		// check same header in the next period can now be submitted successfully
 		assert_ok!(EthereumBeaconClient::submit(RuntimeOrigin::signed(1), update.clone()));
-		let block_root: H256 = update.finalized_header.clone().hash_tree_root().unwrap();
-		assert!(<FinalizedBeaconState<Test>>::contains_key(block_root));
 	});
 }
 
@@ -459,31 +469,6 @@ fn submit_update_with_skipped_period() {
 			EthereumBeaconClient::submit(RuntimeOrigin::signed(1), update),
 			Error::<Test>::SkippedSyncCommitteePeriod
 		);
-	});
-}
-
-#[test]
-fn submit_update_in_next_period_without_sync_committee_update() {
-	let checkpoint = Box::new(load_checkpoint_update_fixture());
-	let sync_committee_update = Box::new(load_sync_committee_update_fixture());
-	let mut update = Box::new(load_next_finalized_header_update_fixture());
-	let next_sync_committee_update = Box::new(load_next_sync_committee_update_fixture());
-
-	new_tester().execute_with(|| {
-		assert_ok!(EthereumBeaconClient::process_checkpoint_update(&checkpoint));
-		assert_ok!(EthereumBeaconClient::submit(
-			RuntimeOrigin::signed(1),
-			sync_committee_update.clone()
-		));
-		assert_err!(
-			EthereumBeaconClient::submit(RuntimeOrigin::signed(1), update.clone()), 
-			SyncCommitteeUpdateRequired
-		);
-		assert_ok!(EthereumBeaconClient::submit(
-			RuntimeOrigin::signed(1),
-			next_sync_committee_update
-		));
-		assert_ok!(EthereumBeaconClient::submit(RuntimeOrigin::signed(1), update));
 	});
 }
 

--- a/bridges/snowbridge/pallets/ethereum-client/src/tests.rs
+++ b/bridges/snowbridge/pallets/ethereum-client/src/tests.rs
@@ -463,6 +463,27 @@ fn submit_update_with_skipped_period() {
 }
 
 #[test]
+fn submit_update_in_next_period_without_sync_committee_update() {
+	let checkpoint = Box::new(load_checkpoint_update_fixture());
+	let sync_committee_update = Box::new(load_sync_committee_update_fixture());
+	let mut update = Box::new(load_next_finalized_header_update_fixture());
+	let next_sync_committee_update = Box::new(load_next_sync_committee_update_fixture());
+
+	new_tester().execute_with(|| {
+		assert_ok!(EthereumBeaconClient::process_checkpoint_update(&checkpoint));
+		assert_ok!(EthereumBeaconClient::submit(
+			RuntimeOrigin::signed(1),
+			sync_committee_update.clone()
+		));
+		assert_ok!(EthereumBeaconClient::submit(RuntimeOrigin::signed(1), update));
+		assert_ok!(EthereumBeaconClient::submit(
+			RuntimeOrigin::signed(1),
+			next_sync_committee_update
+		),);
+	});
+}
+
+#[test]
 fn submit_update_with_sync_committee_in_next_period() {
 	let checkpoint = Box::new(load_checkpoint_update_fixture());
 	let update = Box::new(load_sync_committee_update_fixture());


### PR DESCRIPTION
This change corrects the bug where importing a finalized header in the next sync committee period, without the next sync committee, prevents any subsequent sync committee updates.

## For illustration purposes:
Light client period: `1`
Import header in period `2` (because next sync committee is already known)
Light client period should now be `2`, but it is still `1`.
Current and next sync committee now references the wrong periods, and every subsequent sync committee imports fails because of this check: https://github.com/Snowfork/polkadot-sdk/blob/snowbridge/bridges/snowbridge/pallets/ethereum-client/src/lib.rs#L384

## More Details
A detailed description of the issue here: https://www.notion.so/snowfork/Prod-Investigation-45a74b16488d44249de26f149dbc3ad1

Resolves: [SNO-981](https://linear.app/snowfork/issue/SNO-981)