### PR TITLE
InitiateReserveWithdraw through the bridge

### DIFF
--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/snowbridge.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/snowbridge.rs
@@ -452,7 +452,7 @@ fn send_weth_asset_from_asset_hub_to_ethereum() {
 			WithdrawAsset(assets.clone().into()),
 			BurnAsset(local_fee_asset.clone().into()),
 			SetFeesMode { jit_withdraw: true },
-			InitiateReserveWithdraw {
+			InitiateReserveWithdrawThroughBridge {
 				assets: Definite(vec![remote_fee_asset.clone(), weth_asset.clone()].into()),
 				// with reserve set to Ethereum destination, the ExportMessage will
 				// be appended to the front of the list by the SovereignPaidRemoteExporter

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/snowbridge.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/snowbridge.rs
@@ -388,9 +388,9 @@ fn send_weth_asset_from_asset_hub_to_ethereum() {
 	const WETH_AMOUNT: u128 = 1_000_000_000;
 	const FEE_AMOUNT: u128 = 2_750_872_500_000;
 	// To cover the delivery cost on BH and
-	const LOCAL_FEE_AMOUNT: u128 = DefaultBridgeHubEthereumBaseFee::get();
+	let local_fee_amount: u128 = DefaultBridgeHubEthereumBaseFee::get();
 	// To cover the delivery cost on Ethereum
-	const REMOTE_FEE_AMOUNT: u128 = FEE_AMOUNT - LOCAL_FEE_AMOUNT;
+	let remote_fee_amount: u128 = FEE_AMOUNT - local_fee_amount;
 
 	let weth_asset_location: Location = Location::new(
 		2,
@@ -420,19 +420,13 @@ fn send_weth_asset_from_asset_hub_to_ethereum() {
 	AssetHubRococo::execute_with(|| {
 		type RuntimeOrigin = <AssetHubRococo as Chain>::RuntimeOrigin;
 
-		// DOT as fee asset
-		let fee_asset = Asset { id: AssetId(Location::parent()), fun: Fungible(FEE_AMOUNT) };
-
 		let remote_fee_asset =
-			Asset { id: AssetId(Location::parent()), fun: Fungible(REMOTE_FEE_AMOUNT) };
-
-		let local_fee_asset =
-			Asset { id: AssetId(Location::parent()), fun: Fungible(LOCAL_FEE_AMOUNT) };
+			Asset { id: AssetId(Location::parent()), fun: Fungible(remote_fee_amount) };
 
 		let weth_asset = Asset { id: weth_asset_location.into(), fun: Fungible(WETH_AMOUNT) };
 
 		// Send both assets to BH
-		let assets = vec![fee_asset.clone(), weth_asset.clone()];
+		let assets = vec![remote_fee_asset.clone(), weth_asset.clone()];
 
 		let destination = Location::new(2, [GlobalConsensus(Ethereum { chain_id: CHAIN_ID })]);
 
@@ -450,10 +444,9 @@ fn send_weth_asset_from_asset_hub_to_ethereum() {
 
 		let xcms = VersionedXcm::from(Xcm(vec![
 			WithdrawAsset(assets.clone().into()),
-			BurnAsset(local_fee_asset.clone().into()),
 			SetFeesMode { jit_withdraw: true },
 			InitiateReserveWithdrawThroughBridge {
-				assets: Definite(vec![remote_fee_asset.clone(), weth_asset.clone()].into()),
+				assets: Definite(assets.clone().into()),
 				// with reserve set to Ethereum destination, the ExportMessage will
 				// be appended to the front of the list by the SovereignPaidRemoteExporter
 				reserve: destination,

--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/weights/xcm/mod.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/weights/xcm/mod.rs
@@ -229,4 +229,11 @@ impl<Call> XcmWeightInfo<Call> for AssetHubRococoXcmWeight<Call> {
 	fn unpaid_execution(_: &WeightLimit, _: &Option<Location>) -> Weight {
 		XcmGeneric::<Runtime>::unpaid_execution()
 	}
+	fn initiate_reserve_withdraw_through_bridge(
+		assets: &AssetFilter,
+		_reserve: &Location,
+		_xcm: &Xcm<()>,
+	) -> Weight {
+		assets.weigh_assets(XcmFungibleWeight::<Runtime>::initiate_reserve_withdraw())
+	}
 }

--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/xcm_config.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/xcm_config.rs
@@ -45,7 +45,10 @@ use parachains_common::{
 use polkadot_parachain_primitives::primitives::Sibling;
 use polkadot_runtime_common::xcm_sender::ExponentialPrice;
 use snowbridge_router_primitives::inbound::GlobalConsensusEthereumConvertsFor;
-use sp_runtime::traits::{AccountIdConversion, ConvertInto};
+use sp_runtime::{
+	traits::{AccountIdConversion, ConvertInto},
+	SaturatedConversion,
+};
 use sp_std::marker::PhantomData;
 use testnet_parachains_constants::rococo::snowbridge::{
 	EthereumNetwork, INBOUND_QUEUE_PALLET_INDEX,
@@ -60,15 +63,15 @@ use xcm_builder::{
 	AllowHrmpNotificationsFromRelayChain, AllowKnownQueryResponses, AllowSubscriptionsFrom,
 	AllowTopLevelPaidExecutionFrom, DenyReserveTransferToRelayChain, DenyThenTry,
 	DescribeAllTerminal, DescribeFamily, EnsureXcmOrigin, ExporterFor, FrameTransactionalProcessor,
-	FungibleAdapter, FungiblesAdapter, GlobalConsensusParachainConvertsFor, HashedDescription,
-	InspectMessageQueues, IsConcrete, LocalMint, NetworkExportTableItem, NoChecking,
-	NonFungiblesAdapter, ParentAsSuperuser, ParentIsPreset, RelayChainAsNative,
+	FungibleAdapter, FungiblesAdapter, GlobalConsensusParachainConvertsFor, HandleFee,
+	HashedDescription, InspectMessageQueues, IsConcrete, LocalMint, NetworkExportTableItem,
+	NoChecking, NonFungiblesAdapter, ParentAsSuperuser, ParentIsPreset, RelayChainAsNative,
 	SendXcmFeeToAccount, SiblingParachainAsNative, SiblingParachainConvertsVia,
 	SignedAccountId32AsNative, SignedToAccountId32, SovereignSignedViaLocation, StartsWith,
 	StartsWithExplicitGlobalConsensus, TakeWeightCredit, TrailingSetTopicAsId, UsingComponents,
 	WeightInfoBounds, WithComputedOrigin, WithUniqueTopic, XcmFeeManagerFromComponents,
 };
-use xcm_executor::XcmExecutor;
+use xcm_executor::{traits::FeeReason, XcmExecutor};
 
 parameter_types! {
 	pub const TokenLocation: Location = Location::parent();
@@ -420,7 +423,15 @@ impl xcm_executor::Config for XcmConfig {
 	type AssetExchanger = ();
 	type FeeManager = XcmFeeManagerFromComponents<
 		WaivedLocations,
-		SendXcmFeeToAccount<Self::AssetTransactor, TreasuryAccount>,
+		(
+			SnowbridgeExportFee<
+				Balance,
+				bridging::to_ethereum::BridgeHubEthereumBaseFee,
+				TokenLocation,
+				bridging::to_ethereum::EthereumLocation,
+			>,
+			SendXcmFeeToAccount<Self::AssetTransactor, TreasuryAccount>,
+		),
 	>;
 	type MessageExporter = ();
 	type UniversalAliases =
@@ -533,6 +544,58 @@ impl<Bridges, Router: InspectMessageQueues, UniversalLocation> InspectMessageQue
 {
 	fn get_messages() -> Vec<(VersionedLocation, Vec<VersionedXcm<()>>)> {
 		Router::get_messages()
+	}
+}
+
+pub struct SnowbridgeExportFee<Balance, ExportFeeBalance, FeeAssetLocation, EthereumLocation>(
+	PhantomData<(Balance, ExportFeeBalance, FeeAssetLocation, EthereumLocation)>,
+);
+
+impl<Balance, ExportFeeBalance, FeeAssetLocation, EthereumLocation> HandleFee
+	for SnowbridgeExportFee<Balance, ExportFeeBalance, FeeAssetLocation, EthereumLocation>
+where
+	Balance: From<u128> + Into<u128>,
+	ExportFeeBalance: Get<Balance>,
+	FeeAssetLocation: Get<Location>,
+	EthereumLocation: Get<Location>,
+{
+	fn handle_fee(
+		fees: xcm::prelude::Assets,
+		_context: Option<&XcmContext>,
+		reason: FeeReason,
+	) -> xcm::prelude::Assets {
+		// Check the reason to see if this export is for snowbridge.
+		if !matches!(reason, FeeReason::InitiateReserveWithdrawThroughBridge { destination }
+			if destination == EthereumLocation::get()
+		) || fees.len() != 1
+		{
+			return fees
+		}
+
+		let fee = fees.get(0);
+
+		if let Some(Asset { id: location, .. }) = fee {
+			if location.0 != FeeAssetLocation::get() {
+				return fees
+			}
+		}
+
+		let fee_amount: Option<u128> = if let Some(Asset { fun: Fungible(amount), .. }) = fee {
+			Some(amount.clone())
+		} else {
+			None
+		};
+
+		if fee_amount.is_none() {
+			return fees
+		}
+
+		let export_fee_balance = ExportFeeBalance::get();
+
+		let delivery_fee =
+			fee_amount.unwrap().saturating_sub(export_fee_balance.saturated_into::<u128>());
+
+		return Asset::from((FeeAssetLocation::get(), delivery_fee)).into()
 	}
 }
 
@@ -735,6 +798,8 @@ pub mod bridging {
 					PalletInstance(INBOUND_QUEUE_PALLET_INDEX)
 				]
 			);
+			pub EthereumLocation: Location = Location::new(2, [GlobalConsensus(EthereumNetwork::get())]);
+
 
 			/// Set up exporters configuration.
 			/// `Option<Asset>` represents static "base fee" which is used for total delivery fee calculation.

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/weights/xcm/mod.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/weights/xcm/mod.rs
@@ -229,4 +229,11 @@ impl<Call> XcmWeightInfo<Call> for AssetHubWestendXcmWeight<Call> {
 	fn unpaid_execution(_: &WeightLimit, _: &Option<Location>) -> Weight {
 		XcmGeneric::<Runtime>::unpaid_execution()
 	}
+	fn initiate_reserve_withdraw_through_bridge(
+		assets: &AssetFilter,
+		_reserve: &Location,
+		_xcm: &Xcm<()>,
+	) -> Weight {
+		assets.weigh_assets(XcmFungibleWeight::<Runtime>::initiate_reserve_withdraw())
+	}
 }

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/xcm/mod.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/xcm/mod.rs
@@ -231,4 +231,11 @@ impl<Call> XcmWeightInfo<Call> for BridgeHubRococoXcmWeight<Call> {
 	fn unpaid_execution(_: &WeightLimit, _: &Option<Location>) -> Weight {
 		XcmGeneric::<Runtime>::unpaid_execution()
 	}
+	fn initiate_reserve_withdraw_through_bridge(
+		assets: &AssetFilter,
+		_reserve: &Location,
+		_xcm: &Xcm<()>,
+	) -> Weight {
+		assets.weigh_assets(XcmFungibleWeight::<Runtime>::initiate_reserve_withdraw())
+	}
 }

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/weights/xcm/mod.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/weights/xcm/mod.rs
@@ -232,4 +232,11 @@ impl<Call> XcmWeightInfo<Call> for BridgeHubWestendXcmWeight<Call> {
 	fn unpaid_execution(_: &WeightLimit, _: &Option<Location>) -> Weight {
 		XcmGeneric::<Runtime>::unpaid_execution()
 	}
+	fn initiate_reserve_withdraw_through_bridge(
+		assets: &AssetFilter,
+		_reserve: &Location,
+		_xcm: &Xcm<()>,
+	) -> Weight {
+		assets.weigh_assets(XcmFungibleWeight::<Runtime>::initiate_reserve_withdraw())
+	}
 }

--- a/cumulus/parachains/runtimes/coretime/coretime-rococo/src/weights/xcm/mod.rs
+++ b/cumulus/parachains/runtimes/coretime/coretime-rococo/src/weights/xcm/mod.rs
@@ -229,4 +229,11 @@ impl<Call> XcmWeightInfo<Call> for CoretimeRococoXcmWeight<Call> {
 	fn unpaid_execution(_: &WeightLimit, _: &Option<Location>) -> Weight {
 		XcmGeneric::<Runtime>::unpaid_execution()
 	}
+	fn initiate_reserve_withdraw_through_bridge(
+		assets: &AssetFilter,
+		_reserve: &Location,
+		_xcm: &Xcm<()>,
+	) -> Weight {
+		assets.weigh_assets(XcmFungibleWeight::<Runtime>::initiate_reserve_withdraw())
+	}
 }

--- a/cumulus/parachains/runtimes/coretime/coretime-westend/src/weights/xcm/mod.rs
+++ b/cumulus/parachains/runtimes/coretime/coretime-westend/src/weights/xcm/mod.rs
@@ -229,4 +229,11 @@ impl<Call> XcmWeightInfo<Call> for CoretimeWestendXcmWeight<Call> {
 	fn unpaid_execution(_: &WeightLimit, _: &Option<Location>) -> Weight {
 		XcmGeneric::<Runtime>::unpaid_execution()
 	}
+	fn initiate_reserve_withdraw_through_bridge(
+		assets: &AssetFilter,
+		_reserve: &Location,
+		_xcm: &Xcm<()>,
+	) -> Weight {
+		assets.weigh_assets(XcmFungibleWeight::<Runtime>::initiate_reserve_withdraw())
+	}
 }

--- a/cumulus/parachains/runtimes/people/people-rococo/src/weights/xcm/mod.rs
+++ b/cumulus/parachains/runtimes/people/people-rococo/src/weights/xcm/mod.rs
@@ -234,4 +234,12 @@ impl<Call> XcmWeightInfo<Call> for PeopleRococoXcmWeight<Call> {
 	fn unpaid_execution(_: &WeightLimit, _: &Option<Location>) -> Weight {
 		XcmGeneric::<Runtime>::unpaid_execution()
 	}
+
+	fn initiate_reserve_withdraw_through_bridge(
+		assets: &AssetFilter,
+		_reserve: &Location,
+		_xcm: &Xcm<()>,
+	) -> Weight {
+		assets.weigh_assets(XcmGeneric::<Runtime>::initiate_reserve_withdraw())
+	}
 }

--- a/cumulus/parachains/runtimes/people/people-westend/src/weights/xcm/mod.rs
+++ b/cumulus/parachains/runtimes/people/people-westend/src/weights/xcm/mod.rs
@@ -237,4 +237,11 @@ impl<Call> XcmWeightInfo<Call> for PeopleWestendXcmWeight<Call> {
 	fn unpaid_execution(_: &WeightLimit, _: &Option<Location>) -> Weight {
 		XcmGeneric::<Runtime>::unpaid_execution()
 	}
+	fn initiate_reserve_withdraw_through_bridge(
+		assets: &AssetFilter,
+		_reserve: &Location,
+		_xcm: &Xcm<()>,
+	) -> Weight {
+		assets.weigh_assets(XcmGeneric::<Runtime>::initiate_reserve_withdraw())
+	}
 }

--- a/polkadot/runtime/rococo/src/weights/xcm/mod.rs
+++ b/polkadot/runtime/rococo/src/weights/xcm/mod.rs
@@ -266,6 +266,13 @@ impl<RuntimeCall> XcmWeightInfo<RuntimeCall> for RococoXcmWeight<RuntimeCall> {
 	fn unpaid_execution(_: &WeightLimit, _: &Option<Location>) -> Weight {
 		XcmGeneric::<Runtime>::unpaid_execution()
 	}
+	fn initiate_reserve_withdraw_through_bridge(
+		assets: &AssetFilter,
+		_reserve: &Location,
+		_xcm: &Xcm<()>,
+	) -> Weight {
+		assets.weigh_assets(XcmBalancesWeight::<Runtime>::initiate_reserve_withdraw())
+	}
 }
 
 #[test]

--- a/polkadot/runtime/westend/src/weights/xcm/mod.rs
+++ b/polkadot/runtime/westend/src/weights/xcm/mod.rs
@@ -269,6 +269,14 @@ impl<RuntimeCall> XcmWeightInfo<RuntimeCall> for WestendXcmWeight<RuntimeCall> {
 	fn unpaid_execution(_: &WeightLimit, _: &Option<Location>) -> Weight {
 		XcmGeneric::<Runtime>::unpaid_execution()
 	}
+
+	fn initiate_reserve_withdraw_through_bridge(
+		assets: &AssetFilter,
+		_reserve: &Location,
+		_xcm: &Xcm<()>,
+	) -> Weight {
+		assets.weigh_assets(XcmBalancesWeight::<Runtime>::initiate_reserve_withdraw())
+	}
 }
 
 #[test]

--- a/polkadot/xcm/src/v4/mod.rs
+++ b/polkadot/xcm/src/v4/mod.rs
@@ -1038,6 +1038,11 @@ pub enum Instruction<Call> {
 	///
 	/// Errors: If the given origin is `Some` and not equal to the current Origin register.
 	UnpaidExecution { weight_limit: WeightLimit, check_origin: Option<Location> },
+	InitiateReserveWithdrawThroughBridge {
+		assets: AssetFilter,
+		reserve: Location,
+		xcm: Xcm<()>,
+	},
 }
 
 impl<Call> Xcm<Call> {
@@ -1115,6 +1120,8 @@ impl<Call> Instruction<Call> {
 			AliasOrigin(location) => AliasOrigin(location),
 			UnpaidExecution { weight_limit, check_origin } =>
 				UnpaidExecution { weight_limit, check_origin },
+			InitiateReserveWithdrawThroughBridge { assets, reserve, xcm } =>
+				InitiateReserveWithdrawThroughBridge { assets, reserve, xcm },
 		}
 	}
 }
@@ -1184,6 +1191,8 @@ impl<Call, W: XcmWeightInfo<Call>> GetWeight<W> for Instruction<Call> {
 			AliasOrigin(location) => W::alias_origin(location),
 			UnpaidExecution { weight_limit, check_origin } =>
 				W::unpaid_execution(weight_limit, check_origin),
+			InitiateReserveWithdrawThroughBridge { assets, reserve, xcm } =>
+				W::initiate_reserve_withdraw_through_bridge(assets, reserve, xcm),
 		}
 	}
 }
@@ -1357,6 +1366,12 @@ impl<Call> TryFrom<OldInstruction<Call>> for Instruction<Call> {
 					.map(|location| location.try_into())
 					.transpose()
 					.map_err(|_| ())?,
+			},
+			InitiateReserveWithdrawThroughBridge { assets, reserve, xcm } => {
+				let assets = assets.try_into()?;
+				let reserve = reserve.try_into()?;
+				let xcm = xcm.try_into()?;
+				Self::InitiateReserveWithdrawThroughBridge { assets, reserve, xcm }
 			},
 		})
 	}

--- a/polkadot/xcm/xcm-executor/src/lib.rs
+++ b/polkadot/xcm/xcm-executor/src/lib.rs
@@ -1280,6 +1280,30 @@ impl<Config: config::Config> XcmExecutor<Config> {
 				Config::TransactionalProcessor::process(|| {
 					Config::HrmpChannelClosingHandler::handle(initiator, sender, recipient)
 				}),
+			InitiateReserveWithdrawThroughBridge { assets, reserve, xcm } => {
+				let old_holding = self.holding.clone();
+				let result = Config::TransactionalProcessor::process(|| {
+					// Note that here we are able to place any assets which could not be reanchored
+					// back into Holding.
+					let assets = Self::reanchored(
+						self.holding.saturating_take(assets),
+						&reserve,
+						Some(&mut self.holding),
+					);
+					let mut message = vec![WithdrawAsset(assets), ClearOrigin];
+					message.extend(xcm.0.into_iter());
+					self.send(
+						reserve.clone(),
+						Xcm(message),
+						FeeReason::InitiateReserveWithdrawThroughBridge { destination: reserve },
+					)?;
+					Ok(())
+				});
+				if Config::TransactionalProcessor::IS_TRANSACTIONAL && result.is_err() {
+					self.holding = old_holding;
+				}
+				result
+			},
 		}
 	}
 }

--- a/polkadot/xcm/xcm-executor/src/traits/fee_manager.rs
+++ b/polkadot/xcm/xcm-executor/src/traits/fee_manager.rs
@@ -49,6 +49,9 @@ pub enum FeeReason {
 	LockAsset,
 	/// When the `RequestUnlock` instruction is called.
 	RequestUnlock,
+	InitiateReserveWithdrawThroughBridge {
+		destination: Location,
+	},
 }
 
 impl FeeManager for () {


### PR DESCRIPTION
### Context

Explore the idea from Alistair 

1. The exporter adds the teleported dot to the cost and returns it. This will make sure the user is charged the full amount.
2. In a custom fee handler the Ethereum location must not be waived.
3. In a custom fee handler we check if the the destination is Ethereum(our bridge) then we transfer to the treasury the cost - teleported dot. i.e. burning teleported dot

and solve the issue 

> The challenge here is that in FeeHandler [here](https://github.com/Snowfork/polkadot-sdk/blob/2cef4bd27284a4101d410918427848c0a25f125b/polkadot/xcm/xcm-executor/src/lib.rs#L493),  there is no context of the original destination(i.e. Ethereum) or the Xcm(which contains the ExportMessage to BH). So seems not possible to do the hack above?

 with a custom xcm instruction `InitiateReserveWithdrawThroughBridge`