### PR TITLE
Custom Feehandler & Add destination to FeeReason

### DIFF
--- a/polkadot/xcm/pallet-xcm-benchmarks/src/fungible/benchmarking.rs
+++ b/polkadot/xcm/pallet-xcm-benchmarks/src/fungible/benchmarking.rs
@@ -150,8 +150,8 @@ benchmarks_instance_pallet! {
 
 		let (expected_fees_mode, expected_assets_in_holding) = T::DeliveryHelper::ensure_successful_delivery(
 			&sender_location,
-			&reserve,
-			FeeReason::InitiateReserveWithdraw,
+			&reserve.clone(),
+			FeeReason::InitiateReserveWithdraw{ destination:reserve.clone() },
 		);
 		let sender_account_balance_before = T::TransactAsset::balance(&sender_account);
 
@@ -175,7 +175,7 @@ benchmarks_instance_pallet! {
 		let instruction = Instruction::InitiateReserveWithdraw {
 			// Worst case is looking through all holdings for every asset explicitly - respecting the limit `MAX_ITEMS_IN_ASSETS`.
 			assets: Definite(holding.into_inner().into_iter().take(MAX_ITEMS_IN_ASSETS).collect::<Vec<_>>().into()),
-			reserve,
+			reserve: reserve.clone(),
 			xcm: Xcm(vec![])
 		};
 		let xcm = Xcm(vec![instruction]);

--- a/polkadot/xcm/xcm-executor/src/lib.rs
+++ b/polkadot/xcm/xcm-executor/src/lib.rs
@@ -901,7 +901,11 @@ impl<Config: config::Config> XcmExecutor<Config> {
 					message.extend(xcm.0.into_iter());
 					// put back transport_fee in holding register to be charged by XcmSender
 					self.holding.subsume_assets(transport_fee);
-					self.send(dest, Xcm(message), FeeReason::DepositReserveAsset)?;
+					self.send(
+						dest.clone(),
+						Xcm(message),
+						FeeReason::DepositReserveAsset { destination: dest },
+					)?;
 					Ok(())
 				});
 				if Config::TransactionalProcessor::IS_TRANSACTIONAL && result.is_err() {
@@ -921,7 +925,11 @@ impl<Config: config::Config> XcmExecutor<Config> {
 					);
 					let mut message = vec![WithdrawAsset(assets), ClearOrigin];
 					message.extend(xcm.0.into_iter());
-					self.send(reserve, Xcm(message), FeeReason::InitiateReserveWithdraw)?;
+					self.send(
+						reserve.clone(),
+						Xcm(message),
+						FeeReason::InitiateReserveWithdraw { destination: reserve },
+					)?;
 					Ok(())
 				});
 				if Config::TransactionalProcessor::IS_TRANSACTIONAL && result.is_err() {

--- a/polkadot/xcm/xcm-executor/src/traits/fee_manager.rs
+++ b/polkadot/xcm/xcm-executor/src/traits/fee_manager.rs
@@ -34,9 +34,9 @@ pub enum FeeReason {
 	/// When the `TransferReserveAsset` instruction is called.
 	TransferReserveAsset,
 	/// When the `DepositReserveAsset` instruction is called.
-	DepositReserveAsset,
+	DepositReserveAsset { destination: Location },
 	/// When the `InitiateReserveWithdraw` instruction is called.
-	InitiateReserveWithdraw,
+	InitiateReserveWithdraw { destination: Location },
 	/// When the `InitiateTeleport` instruction is called.
 	InitiateTeleport,
 	/// When the `QueryPallet` instruction is called.


### PR DESCRIPTION
### Context

Explore the idea from Alistair 

1. The exporter adds the teleported dot to the cost and returns it. This will make sure the user is charged the full amount.
2. In a custom fee handler the Ethereum location must not be waived.
3. In a custom fee handler we check if the the destination is Ethereum(our bridge) then we transfer to the treasury the cost - teleported dot. i.e. burning teleported dot

and solve the issue 

> The challenge here is that in FeeHandler [here](https://github.com/Snowfork/polkadot-sdk/blob/2cef4bd27284a4101d410918427848c0a25f125b/polkadot/xcm/xcm-executor/src/lib.rs#L493),  there is no context of the original destination(i.e. Ethereum). So seems not possible to do the hack above?

 with destination(i.e. Ethereum) added into the `FeeReason` of  `InitiateReserveWithdraw`.